### PR TITLE
Potential fix for code scanning alert no. 18: Exposure of private information

### DIFF
--- a/Bucstop WebApp/BucStop/Controllers/AccountController.cs
+++ b/Bucstop WebApp/BucStop/Controllers/AccountController.cs
@@ -13,6 +13,18 @@ namespace BucStop.Controllers
 
         private readonly ILogger<AccountController> _logger;
 
+        // Helper method to mask email addresses for logs
+        private string MaskEmail(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return "";
+            var atIdx = email.IndexOf('@');
+            if (atIdx <= 1)
+                return "***" + email.Substring(atIdx);
+            // show first letter, mask rest before @
+            return email.Substring(0, 1) + "***" + email.Substring(atIdx);
+        }
+
         public AccountController(ILogger<AccountController> logger)
         {
             _logger = logger;
@@ -68,7 +80,7 @@ namespace BucStop.Controllers
             else
             {
                 // Authentication failed, return to the login page with an error message
-                _logger.LogWarning("{Category}: Invalid login attempt for {Email}", "InvalidLogin", email);
+                _logger.LogWarning("{Category}: Invalid login attempt for {MaskedEmail}", "InvalidLogin", MaskEmail(email));
                 ModelState.AddModelError(string.Empty, "Only ETSU students can play, sorry :(");
 
                 stopwatch.Stop();


### PR DESCRIPTION
Potential fix for [https://github.com/Andersonjb1/BucStop-QWERTY/security/code-scanning/18](https://github.com/Andersonjb1/BucStop-QWERTY/security/code-scanning/18)

The best way to fix this problem is to avoid logging the full email address to external logs, or to redact/mask the PII. Logging login failures can still be informationally valuable; you could log a partially masked version of the email (e.g. `"e***@etsu.edu"`). The changes to make:

- Edit the log message on line 71 to avoid writing the complete email address.
- Implement a helper method within the controller to mask email addresses.
- Use this helper to partially mask the email before logging.

This change is local to the `AccountController.cs` file. Add a helper masking function and update the log statement to use it. No extra imports are required beyond what's present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
