### PR TITLE
Comment out service dependencies in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     environment:
       - DOTNET_ENVIRONMENT=${env:-containers}
       - GIT_COMMIT_HASH=${GIT_COMMIT:-unknown}
-    depends_on:
-      - api-gateway
+    #depends_on:
+    #  - api-gateway
     volumes:
       - snapshots-data:/app/Snapshots
       - logs-data:/app/Logs
@@ -29,10 +29,10 @@ services:
       - bucstop-network
     environment:
       - DOTNET_ENVIRONMENT=${env:-containers}
-    depends_on:
-      - snake
-      - pong
-      - tetris
+    #depends_on:
+    #  - snake
+    #  - pong
+    #  - tetris
 
   snake:
     build:


### PR DESCRIPTION
Comment out dependencies for api-gateway, snake, pong, and tetris services as they can start independently without seemingly any issues.