### PR TITLE
Update README and add docker-compose.dev.yml for local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The application is built using a microservices architecture with the following c
    cd BucStop-QWERTY
    ```
 
-2. Start all services using Docker Compose:
+2. Start all services locally using Docker Compose specifying the .dev version:
    ```
-   env=containersLocal docker compose up -d
+   sudo env=containersLocal docker compose -f docker-compose.dev.yml build --no-cache
    ```
 
 3. Access the application:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,126 @@
+
+# To run this and test your changes locally run the following command:
+#
+#  sudo env=containersLocal docker compose -f docker-compose.dev.yml build --no-cache
+#
+
+services:
+  bucstop:
+    build:
+      context: ./Bucstop_WebApp/BucStop
+      dockerfile: Dockerfile
+    container_name: bucstop
+    ports:
+      - "8080:80"
+    networks:
+      - bucstop-network
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+      - GIT_COMMIT_HASH=${GIT_COMMIT:-unknown}
+    depends_on:
+      - api-gateway
+    volumes:
+      - snapshots-data:/app/Snapshots
+      - logs-data:/app/Logs
+
+  api-gateway:
+    build:
+      context: ./Team-3-BucStop_APIGateway/APIGateway
+      dockerfile: Dockerfile
+    container_name: api-gateway
+    ports:
+      - "8081:80" # Expose API Gateway on localhost:8081
+    networks:
+      - bucstop-network
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+    depends_on:
+      - snake
+      - pong
+      - tetris
+
+  snake:
+    build:
+      context: ./Team-3-BucStop_Snake/Snake
+      dockerfile: Dockerfile
+    container_name: game-snake
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+    ports:
+      - "8082:80" # Expose Snake microservice on localhost:8082
+    networks:
+      - bucstop-network
+
+  pong:
+    build:
+      context: ./Team-3-BucStop_Pong/Pong
+      dockerfile: Dockerfile
+    container_name: game-pong
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+    ports:
+      - "8083:80" # Expose Pong microservice on localhost:8083
+    networks:
+      - bucstop-network
+
+  tetris:
+    build:
+      context: ./Team-3-BucStop_Tetris/Tetris
+      dockerfile: Dockerfile
+    container_name: game-tetris
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+    ports:
+      - "8084:80" # Expose Tetris microservice on localhost:8084
+    networks:
+      - bucstop-network
+
+  submission-gateway:
+    # Uncomment the following next 3 lines once the code for the Submission Gateway is added.
+    #build:
+    #context: ./BucStop_SubmissionGateway/SubmissionGateway
+    #dockerfile: Dockerfile
+    # Using a placeholder "hello world" image since there isn't code to build yet.
+    image: "hello-world" # This line should be deleted once Submission Gateway is implemented.
+    container_name: submission-gateway
+    ports:
+      - "8085:80"
+    networks:
+      - bucstop-network
+    environment:
+      - DOTNET_ENVIRONMENT=${env:-containers}
+    volumes:
+      - submission-data:/app/Submissions
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    ports:
+      - "9000:80"
+    networks:
+      - bucstop-network
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    # The following commands:
+    # interval - the interval watchtower will check our container images
+    # cleanup - removes the older images after the update
+    # rolling-restart - updates one container at a time
+    command: >
+      --interval 30
+      --cleanup
+      --rolling-restart
+    environment:
+      - TZ=America/New_York # set your timezone (e.g. America/New_York)
+
+networks:
+  bucstop-network:
+    driver: bridge
+
+volumes:
+  snapshots-data:
+    driver: local
+  logs-data:
+    driver: local
+  submission-data:
+    driver: local

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-
 # To run this and test your changes locally run the following command:
 #
 #  sudo env=containersLocal docker compose -f docker-compose.dev.yml build --no-cache
@@ -15,10 +14,8 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
       - GIT_COMMIT_HASH=${GIT_COMMIT:-unknown}
-    depends_on:
-      - api-gateway
     volumes:
       - snapshots-data:/app/Snapshots
       - logs-data:/app/Logs
@@ -33,11 +30,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
-    depends_on:
-      - snake
-      - pong
-      - tetris
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
 
   snake:
     build:
@@ -45,7 +38,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-snake
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8082:80" # Expose Snake microservice on localhost:8082
     networks:
@@ -57,7 +50,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-pong
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8083:80" # Expose Pong microservice on localhost:8083
     networks:
@@ -69,7 +62,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-tetris
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8084:80" # Expose Tetris microservice on localhost:8084
     networks:
@@ -88,7 +81,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=${env:-containers}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     volumes:
       - submission-data:/app/Submissions
 


### PR DESCRIPTION
This pull request introduces a new `docker-compose.dev.yml` file to streamline local development and testing of the BucStop microservices architecture. It also updates the setup instructions in the `README.md` to reference this new workflow. The most important changes are grouped below:

**Local Development Workflow:**

* Added `docker-compose.dev.yml` with service definitions for all core microservices (`bucstop`, `api-gateway`, `snake`, `pong`, `tetris`, `submission-gateway`) and supporting infrastructure (`watchtower`), including build contexts, ports, environment variables, and volumes.
* Updated `README.md` to instruct developers to build and run services locally using the new compose file and the `--no-cache` flag for fresh builds.