### PR TITLE
173 blaine

### DIFF
--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs == "true" }}
+    if: ${{ needs.detect-changes.outputs != " " }}
     strategy:
       fail-fast: false
       matrix:
@@ -125,8 +125,8 @@ jobs:
           svc=${{ matrix.service }}
           case "$svc" in
             webapp)
-              path="BucStop_WebApp/BucStop"
-              dockerfile="BucStop_WebApp/BucStop/Dockerfile"
+              path="Bucstop_WebApp/BucStop"
+              dockerfile="Bucstop_WebApp/BucStop/Dockerfile"
               ;;
             gateway)
               path="Team-3-BucStop_APIGateway/APIGateway"

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -6,7 +6,7 @@
 # - Ensures at the end that all 5 service images exist in GHCR (builds any missing ones from the default branch)
 #
 # Services:
-# - webapp  -> "BucStop_WebApp/BucStop/"
+# - webapp  -> "Bucstop_WebApp/BucStop/"
 # - gateway -> "Team-3-BucStop_APIGateway/APIGateway/"
 # - snake   -> "Team-3-BucStop_Snake/Snake/"
 # - pong    -> "Team-3-BucStop_Pong/Pong/"
@@ -56,8 +56,8 @@ jobs:
         with:
           filters: |
             webapp:
-              - 'BucStop_WebApp/BucStop/**'
-              - 'BucStop_WebApp/**'
+              - 'Bucstop_WebApp/BucStop/**'
+              - 'Bucstop_WebApp/**'
               - 'BucStop/**'
             gateway:
               - 'Team-3-BucStop_APIGateway/APIGateway/**'
@@ -105,12 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    ##################################################
-
-    # if anything ever breaks, check this if statement first
-
-    ##################################################
-    if: ${{ needs.detect-changes.outputs.services }}
+    if: ${{ needs.detect-changes.outputs == "true" }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs.services }}
+    #if: ${{ needs.detect-changes.outputs.services }}
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +123,10 @@ jobs:
         id: set-path
         run: |
           svc=${{ matrix.service }}
+          if [[ -z "$svc" ]]; then
+            echo "No service provided to build-changed matrix. Exiting as expected."
+            exit 0
+          fi
           case "$svc" in
             webapp)
               path="Bucstop_WebApp/BucStop"

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs != " " }}
+    if: ${{ needs.detect-changes.outputs.services }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request makes several updates to the GitHub Actions workflow configuration for deploying microservice images. The main focus is on standardizing the naming convention for the `webapp` service directory from `BucStop_WebApp` to `Bucstop_WebApp` across various workflow steps, and improving robustness in the build matrix handling.

Key changes include:

**Directory Naming Standardization:**

* Updated all references to the `webapp` service directory in the workflow filters, build paths, and documentation from `BucStop_WebApp` to `Bucstop_WebApp` to ensure consistency and prevent build errors. [[1]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872L9-R9) [[2]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872L59-R60) [[3]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872R126-R133)

**Workflow Robustness:**

* Added a check in the build matrix step to gracefully exit if no service is provided, preventing unnecessary errors during the build process.
* Commented out the conditional that restricts the build job to only run when services are detected as changed, possibly for debugging or troubleshooting purposes.