### PR TITLE
173 blaine

### DIFF
--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,11 +105,12 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
+    #if: needs.detect-changes.outputs.services != ''
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
-    if: matrix.service
+    if: ${{ matrix.service }}
     env:
       GHCR_REGISTRY: ghcr.io
       IMAGE_NAMESPACE: ${{ needs.set-namespace.outputs.namespace }}

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs == "true" }}
+    if: ${{ needs.detect-changes.outputs != " " }}
     strategy:
       fail-fast: false
       matrix:
@@ -125,8 +125,8 @@ jobs:
           svc=${{ matrix.service }}
           case "$svc" in
             webapp)
-              path="BucStop_WebApp/BucStop"
-              dockerfile="BucStop_WebApp/BucStop/Dockerfile"
+              path="Bucstop_WebApp/BucStop"
+              dockerfile="Bucstop_WebApp/BucStop/Dockerfile"
               ;;
             gateway)
               path="Team-3-BucStop_APIGateway/APIGateway"

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,12 +105,11 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    #if: needs.detect-changes.outputs.services != ''
+    if: needs.detect-changes.outputs.services != ''
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
-    if: ${{ matrix.service }}
     env:
       GHCR_REGISTRY: ghcr.io
       IMAGE_NAMESPACE: ${{ needs.set-namespace.outputs.namespace }}

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -6,7 +6,7 @@
 # - Ensures at the end that all 5 service images exist in GHCR (builds any missing ones from the default branch)
 #
 # Services:
-# - webapp  -> "BucStop_WebApp/BucStop/"
+# - webapp  -> "Bucstop_WebApp/BucStop/"
 # - gateway -> "Team-3-BucStop_APIGateway/APIGateway/"
 # - snake   -> "Team-3-BucStop_Snake/Snake/"
 # - pong    -> "Team-3-BucStop_Pong/Pong/"
@@ -56,8 +56,8 @@ jobs:
         with:
           filters: |
             webapp:
-              - 'BucStop_WebApp/BucStop/**'
-              - 'BucStop_WebApp/**'
+              - 'Bucstop_WebApp/BucStop/**'
+              - 'Bucstop_WebApp/**'
               - 'BucStop/**'
             gateway:
               - 'Team-3-BucStop_APIGateway/APIGateway/**'
@@ -105,12 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    ##################################################
-
-    # if anything ever breaks, check this if statement first
-
-    ##################################################
-    if: ${{ needs.detect-changes.outputs.services }}
+    if: ${{ needs.detect-changes.outputs == "true" }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -82,8 +82,12 @@ jobs:
           [[ "${{ steps.filter.outputs.pong }}" == 'true' ]] && changed+=('pong')
           [[ "${{ steps.filter.outputs.tetris }}" == 'true' ]] && changed+=('tetris') 
 
-          echo "services=$(jq -nc --argjson arr "$(printf '%s\n' "${changed[@]}" | jq -R . | jq -s .)" '$arr')" >> "$GITHUB_OUTPUT"
-
+          if [ ${#changed[@]} -eq 0 ]; then
+            echo "services=[]" >> "$GITHUB_OUTPUT"
+            echo "No changed services detected -> services=[]"
+          else
+            echo "services=$(jq -nc --argjson arr "$(printf '%s\n' "${changed[@]}" | jq -R . | jq -s .)" '$arr')" >> "$GITHUB_OUTPUT"
+          fi
           echo "$services"
           echo ${changed[@]}
 
@@ -105,7 +109,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: needs.detect-changes.outputs.services != '' && needs.detect-changes.outputs.services != '[]'
+    if: needs.detect-changes.outputs.services != '[]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -84,7 +84,7 @@ jobs:
 
           echo "services=$(jq -nc --argjson arr "$(printf '%s\n' "${changed[@]}" | jq -R . | jq -s .)" '$arr')" >> "$GITHUB_OUTPUT"
 
-          echo $services
+          echo "$services"
           echo ${changed[@]}
 
   set-namespace:
@@ -105,11 +105,11 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    #if: ${{ needs.detect-changes.outputs.services }}
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJson(needs.detect-changes.outputs.services) }}
+    if: matrix.service
     env:
       GHCR_REGISTRY: ghcr.io
       IMAGE_NAMESPACE: ${{ needs.set-namespace.outputs.namespace }}
@@ -123,10 +123,6 @@ jobs:
         id: set-path
         run: |
           svc=${{ matrix.service }}
-          if [[ -z "$svc" ]]; then
-            echo "No service provided to build-changed matrix. Exiting as expected."
-            exit 0
-          fi
           case "$svc" in
             webapp)
               path="Bucstop_WebApp/BucStop"

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs.services }}
+    #if: ${{ needs.detect-changes.outputs.services }}
     strategy:
       fail-fast: false
       matrix:
@@ -123,6 +123,10 @@ jobs:
         id: set-path
         run: |
           svc=${{ matrix.service }}
+          if [[ -z "$svc" ]]; then
+            echo "No service provided to build-changed matrix. Exiting as expected."
+            exit 0
+          fi
           case "$svc" in
             webapp)
               path="Bucstop_WebApp/BucStop"

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ needs.detect-changes.outputs != " " }}
+    if: ${{ needs.detect-changes.outputs.services }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/DeployToGHCR.yml
+++ b/.github/workflows/DeployToGHCR.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build & push changed microservice images
     needs: [set-namespace, detect-changes]
     runs-on: ubuntu-latest
-    if: needs.detect-changes.outputs.services != ''
+    if: needs.detect-changes.outputs.services != '' && needs.detect-changes.outputs.services != '[]'
     strategy:
       fail-fast: false
       matrix:
@@ -143,6 +143,10 @@ jobs:
             tetris)
               path="Team-3-BucStop_Tetris/Tetris"
               dockerfile="Team-3-BucStop_Tetris/Tetris/Dockerfile"
+              ;;
+            ""|0)
+              echo "no changed services detected"
+              exit 0
               ;;
             *)
               echo "Unknown service: $svc"


### PR DESCRIPTION
This pull request primarily addresses improvements and fixes in the GitHub Actions workflow for deploying microservices. The workflow changes focus on correcting path casing issues for the `webapp` service, improving detection and handling of changed services, and making the build process more robust.

**GitHub Actions workflow improvements:**

* Fixed inconsistent casing in all references to the `webapp` service directory and Dockerfile paths from `BucStop_WebApp` to `Bucstop_WebApp` in `.github/workflows/DeployToGHCR.yml` to ensure correct service detection and build paths. [[1]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872L9-R9) [[2]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872L59-R60) [[3]](diffhunk://#diff-7eb4cfeac87eb85c8be54a7de001496148caf69d4dd5097d033e2e3fca1ed872L133-R133)
* Improved detection logic for changed services: now explicitly sets `services=[]` and logs a message when no changes are detected, preventing unnecessary workflow runs.
* Updated the build job condition to only run when there are actually changed services (`needs.detect-changes.outputs.services != '[]'`), making the workflow more efficient and eliminating a confusing comment block.
* Added a case to gracefully handle empty or zero-value service names in the build matrix, ensuring the script exits cleanly when no services need to be built.