### PR TITLE
Fix logo image path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BucStop
 
-![BucStop Logo](/Bucstop%20WebApp/BucStop/wwwroot/Logo.png)
+![BucStop Logo](/Bucstop_WebApp/BucStop/wwwroot/Logo.png)
 
 ## Overview
 


### PR DESCRIPTION
This pull request updates the image path in the `README.md` file to fix a broken logo reference. 

- Updated the logo image path in `README.md` to use the correct directory structure.