### PR TITLE
Fix for ReDoS vulnerability in "url2" validation method.

### DIFF
--- a/Bucstop_WebApp/BucStop/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Bucstop_WebApp/BucStop/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -1089,7 +1089,12 @@ $.validator.addMethod( "time12h", function( value, element ) {
 
 // Same as url, but TLD is optional
 $.validator.addMethod( "url2", function( value, element ) {
-	return this.optional( element ) || /^(https?|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)*(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test( value );
+    // Simpler, ReDoS-safe URL which checks: 
+	// protocol + "://" + at least one non-space char
+    var url2Pattern = /^(https?|ftp):\/\/\S+$/i;
+
+    return this.optional( element ) || url2Pattern.test( value );
+
 }, $.validator.messages.url );
 
 /**


### PR DESCRIPTION
This original pattern was extremely long, deeply nested, and contained multiple repeating groups (+, *) inside alternations. Those characteristics can cause catastrophic backtracking, where certain malicious inputs make the JavaScript engine take exponential time to evaluate the regex. This type of attack is known as ReDoS (Regular Expression Denial of Service). 

Instead of trying to repair the overly complex built-in regex, I replaced the entire validation pattern with a simple, linear-time expression that still correctly enforces basic URL format without introducing ReDoS risk.
The new regex does not contain nested quantifiers, removing the possibility of exponential backtracking. 

It safely checks for:
- A valid protocol (http, https, or ftp)
- Followed by ://
- Followed by at least one non-whitespace character

The performance of the regex is now O(n) instead of the previous O(2ⁿ).