### PR TITLE
Implement reject submission folder deletion

### DIFF
--- a/Bucstop_WebApp/BucStop/Controllers/SubmissionAdminController.cs
+++ b/Bucstop_WebApp/BucStop/Controllers/SubmissionAdminController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+
+namespace BucStop.Controllers
+{
+    [ApiController]
+    [Route("admin/submissions")]
+    public class SubmissionAdminController : Controller
+    {
+        [HttpDelete("{folderName}")]
+        public IActionResult RejectSubmission(string folderName)
+        {
+            string fullPath = $"/app/Submissions/{folderName}";
+
+            try
+            {
+                if (!Directory.Exists(fullPath))
+                {
+                    return NotFound(new { success = false, message = "Folder not found" });
+                }
+
+                Directory.Delete(fullPath, recursive: true);
+
+                return Ok(new { success = true, folder = folderName });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { success = false, message = ex.Message });
+            }
+        }
+    }
+}

--- a/Bucstop_WebApp/BucStop/MicroServices/GameInfo.cs
+++ b/Bucstop_WebApp/BucStop/MicroServices/GameInfo.cs
@@ -11,5 +11,6 @@
         public string HowTo { get; set; }
         public string Thumbnail { get; set; }
         public Stack<KeyValuePair<string, int>> LeaderBoard { get; set; }
+        public string FolderName { get; set; } = string.Empty;
     }
 }

--- a/Bucstop_WebApp/BucStop/MicroServices/SubmissionClient.cs
+++ b/Bucstop_WebApp/BucStop/MicroServices/SubmissionClient.cs
@@ -76,25 +76,26 @@ namespace BucStop
 
         foreach (GameInfo info in gameInfos)
         {
-          Game game = new Game();
+            if (info == null)
+                continue;
 
-          if (info != null)
-          {
-            game.Id = info.Id;
-            game.Title = info.Title;
-            game.Content = info.Content;
-            game.Thumbnail = info.Thumbnail;
-            game.Author = info.Author;
-            game.HowTo = info.HowTo;
-            game.DateAdded = info.DateAdded;
-            game.Description = $"{info.Description} \n {info.DateAdded}";
-            game.LeaderBoard = info.LeaderBoard;
+            Game game = new Game
+            {
+                Id = info.Id,
+                Title = info.Title,
+                Content = info.Content,
+                Thumbnail = info.Thumbnail,
+                Author = info.Author,
+                HowTo = info.HowTo,
+                DateAdded = info.DateAdded,
+                Description = $"{info.Description} \n {info.DateAdded}",
+                LeaderBoard = info.LeaderBoard,
+                FolderName = info.FolderName // <-- IMPORTANT
+            };
 
             _logger.LogInformation("Game ID {Id} Content URL: {Content}", info.Id, info.Content);
 
-          }
-
-          games.Add(game);
+            games.Add(game);
         }
       }
       catch (Exception ex)

--- a/Bucstop_WebApp/BucStop/Models/Game.cs
+++ b/Bucstop_WebApp/BucStop/Models/Game.cs
@@ -48,6 +48,9 @@ namespace BucStop.Models
         public Stack<KeyValuePair<string, int>> LeaderBoard { get; set; }
         public int PlayCount { get; set; }
 
+        // The name of the folder containing the game files.
+        public string FolderName { get; set; } = string.Empty;
+
         /*public async Task OnGet([FromServices] MicroClient microClient)
         {
             Info = await microClient.GetGamesAsync  ();

--- a/Bucstop_WebApp/BucStop/Views/Home/Admin.cshtml
+++ b/Bucstop_WebApp/BucStop/Views/Home/Admin.cshtml
@@ -53,12 +53,12 @@
                 <div class="image-wrapper">
                     <a href="@Url.Action("Test", "Games", new { id = game.Id })" style="text-decoration: none;">
                         <!--<img src="@game.Thumbnail" class="card-img-top">
-                                            <div class="card-body">
-                                                <h5 class="card-title">@game.Title</h5>
-                                                <p class="card-text"><small class="text-muted">@game.Description</small></p>
-                                                <p class="text-muted">Play Count: @game.PlayCount</p>
-                                            </div>
-                                                -->
+                                                <div class="card-body">
+                                                    <h5 class="card-title">@game.Title</h5>
+                                                    <p class="card-text"><small class="text-muted">@game.Description</small></p>
+                                                    <p class="text-muted">Play Count: @game.PlayCount</p>
+                                                </div>
+                                                    -->
                         <div class="card-body">
                             <img src="@game.Thumbnail" class="card-img-top image" alt="@game.Title">
                         </div>
@@ -76,7 +76,8 @@
                     <button type="button" class="btn btn-success btn-sm" disabled>
                         Approve
                     </button>
-                    <button type="button" class="btn btn-danger btn-sm ms-2" disabled>
+                    <button type="button" class="btn btn-danger btn-sm ms-2"
+                            onclick="rejectSubmission('@game.FolderName', this)">
                         Reject
                     </button>
                 </div>
@@ -85,3 +86,31 @@
         </div>
     }
 </div>
+
+@section Scripts {
+<script>
+    function rejectSubmission(folderName, btn) {
+        if (!confirm("Reject this submission?")) return;
+
+        fetch(`/admin/submissions/${folderName}`, {
+            method: 'DELETE'
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+
+                // Remove the card visually
+                const card = btn.closest(".card");
+                if (card) card.remove();
+
+            } else {
+                alert("Failed to delete submission.");
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            alert("Server error: " + err);
+        });
+    }
+</script>
+}

--- a/Team-QWERTY-BucStop_Submission/SubmissionAPIGateway/Controllers/SubmissionGatewayController.cs
+++ b/Team-QWERTY-BucStop_Submission/SubmissionAPIGateway/Controllers/SubmissionGatewayController.cs
@@ -47,6 +47,8 @@ namespace Gateway
                     try
                     {
                         _logger.LogInformation("Processing folder: {Folder}", folder);
+                        // extract folder name
+                        var folderName = Path.GetFileName(folder);
 
                         // Below finds the json files
                         var jsonFiles = Directory.GetFiles(folder, "*.json");
@@ -102,7 +104,9 @@ namespace Gateway
                                     DateAdded = DateTime.UtcNow.ToString("yyyy-MM-dd"),
                                     Thumbnail = sub.SuggestedThumbnailUrl ?? "",
                                     Content = jsRelativePath,
-                                    LeaderBoardStack = GenerateDummyLeaderboard()
+                                    LeaderBoardStack = GenerateDummyLeaderboard(),
+
+                                    FolderName = folderName
                                 };
 
                                 _logger.LogInformation("Added game: {Title} by {Author}", game.Title, game.Author);

--- a/Team-QWERTY-BucStop_Submission/SubmissionAPIGateway/GameInfo.cs
+++ b/Team-QWERTY-BucStop_Submission/SubmissionAPIGateway/GameInfo.cs
@@ -11,5 +11,6 @@ namespace Gateway
         public string HowTo { get; set; }
         public string Thumbnail { get; set; }
         public Stack<KeyValuePair<string, int>> LeaderBoardStack { get; set; }
+        public string FolderName { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
This PR enables admins to remove game submissions directly from the UI. Clicking "Reject" should not only remove the game from the page but it should remove its folder from the submission volume as well. 

- Adds FolderName to GameInfo and propagates it through the submission pipeline
- Implements a DELETE endpoint to remove submission folders from the volume
- Updates Admin page to send delete requests and remove cards dynamically
- Includes error handling and logging for missing folders or failures