### PR TITLE
This fixes the Workflow does not contain permissions to read repository contents issue.

### DIFF
--- a/.github/workflows/navigation-test.yml
+++ b/.github/workflows/navigation-test.yml
@@ -1,5 +1,8 @@
 name: Automated Selenium Testing
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -42,13 +45,13 @@ jobs:
 
     - name: Build and Start Containers
       run: |
-         timeout 300s bash -c '
-           env=containersLocal docker compose up -d
-           echo "Waiting for containers to start..."
-           docker compose wait || echo "docker compose wait timed out or failed"
-         ' 
-         sleep 5
-         docker ps -a || true
+          timeout 300s bash -c '
+            env=containersLocal docker compose up -d
+            echo "Waiting for containers to start..."
+            docker compose wait || echo "docker compose wait timed out or failed"
+          ' 
+          sleep 5
+          docker ps -a || true
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/service-smoke-test.yml
+++ b/.github/workflows/service-smoke-test.yml
@@ -1,6 +1,8 @@
 name: Service Smoke Tests
 
-on:
+permissions:
+  contents: read
+
   pull_request:
     branches: ["**"]  # Run for PRs targeting any branch
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/tests_dotnet.yml
+++ b/.github/workflows/tests_dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET Tests (any branch, PR + post-merge)
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ["**"]
@@ -42,7 +45,7 @@ jobs:
           for p in "${ALL_CS[@]}"; do
             # Check for test-related package references or <IsTestProject>
             if grep -qE '<PackageReference .*Microsoft\.NET\.Test\.Sdk|<PackageReference .*xunit|<PackageReference .*xunit\.runner|<PackageReference .*MSTest\.TestAdapter|<PackageReference .*NUnit|<PackageReference .*coverlet\.collector' "$p" \
-               || grep -q '<IsTestProject>true</IsTestProject>' "$p"; then
+              || grep -q '<IsTestProject>true</IsTestProject>' "$p"; then
               TESTS+=("$p")
             else
               # Fallback: detect test projects by filename/path


### PR DESCRIPTION
This resolves three security alerts related to missing workflow permissions:

Alert #37 — .github/workflows/service-smoke-test.yml
Alert #38 — .github/workflows/tests_dotnet.yml
Alert #39 — .github/workflows/navigation-test.yml

All three warnings were triggered because the workflows did not explicitly define a permissions: section.
GitHub defaults older repositories to a read–write GITHUB_TOKEN, which violates the principle of least privilege and is flagged as a security risk. This adds a minimal permissions block to each workflow, reducing GitHub token access to read-only, which is all these workflows require.