### PR TITLE
This fixes security alerts #45 and #46 by sanitizing user input to pr…

### DIFF
--- a/Bucstop_WebApp/BucStop/Controllers/SubmissionAdminController.cs
+++ b/Bucstop_WebApp/BucStop/Controllers/SubmissionAdminController.cs
@@ -10,8 +10,32 @@ namespace BucStop.Controllers
         [HttpDelete("{folderName}")]
         public IActionResult RejectSubmission(string folderName)
         {
-            string fullPath = $"/app/Submissions/{folderName}";
+            const string Root = "/app/Submissions";
+            // Validate input
+            if (string.IsNullOrWhiteSpace(folderName))
+                return BadRequest(new { success = false, message = "Folder name is required." });
+            // Sanitize folder name
+            string safeFolderName = System.Text.RegularExpressions.Regex.Replace(
+                folderName,
+                @"[^A-Za-z0-9._-]",   // allowed characters
+                "_"
+            ).Replace("..", "_");       // prevent parent directory traversal
 
+            if (safeFolderName.Length == 0)
+                return BadRequest(new { success = false, message = "Invalid folder name." });
+            // Combine with root path    
+            string candidatePath = Path.Combine(Root, safeFolderName);
+
+            // Normalize and enforce it stays under /app/Submissions
+            string fullPath = Path.GetFullPath(candidatePath);
+
+            string fullRoot = Path.GetFullPath(Root)
+                .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+            if (!fullPath.StartsWith(fullRoot, StringComparison.Ordinal))
+                return BadRequest(new { success = false, message = "Invalid folder path." });
+
+            // Perform deletion
             try
             {
                 if (!Directory.Exists(fullPath))
@@ -21,7 +45,7 @@ namespace BucStop.Controllers
 
                 Directory.Delete(fullPath, recursive: true);
 
-                return Ok(new { success = true, folder = folderName });
+                return Ok(new { success = true, folder = safeFolderName });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
These alerts were triggered because the previous implementation constructed file-system paths directly from the user-controlled folderName parameter. This created a potential directory traversal vulnerability, allowing malicious paths such as ../../etc/passwd, /tmp, or strings containing .. to escape the expected submissions directory.

This PR replaces the vulnerable code with a safe, validated, sanitized, and normalized path-handling workflow, ensuring the dangerous operations are only executed on paths contained within /app/Submissions.